### PR TITLE
Allows Relationship type to be preselected

### DIFF
--- a/README
+++ b/README
@@ -25,6 +25,13 @@ INSTALLATION
             'RT::Extension::SpawnLinkedTicketInQueue',
         );
 
+    Then, if you want a specific ticket link relationship type preselected, you
+    make an entry into the configuration etc/RT_SiteConfig.pm.  The available
+    link type names are how tickets can be related to each other 
+    (depends on/depended on by/parents/children/refers to/referred to by):
+
+        Set($SpawnTicketInQueueLinkDefault => 'Children');
+
     Flush mason cache:
 
         rm -rf /opt/rt3/var/mason_data/obj

--- a/html/Callbacks/SpawnLinkedTicket/Elements/ShowLinks/Default
+++ b/html/Callbacks/SpawnLinkedTicket/Elements/ShowLinks/Default
@@ -54,12 +54,12 @@
 <input type="hidden" name="CloneTicket" value="<% $Object->id %>">
 <input type="submit" value="<&|/l&>Create</&>" name="SpawnLinkedTicket">
 <select name="LinkType">
-<option value="DependsOn-new"><% loc('Depends on') %></option>
-<option value="new-DependsOn"><% loc('Depended on by') %></option>
-<option value="MemberOf-new"><% loc('Parents') %></option>
-<option value="new-MemberOf"><% loc('Children') %></option>
-<option value="RefersTo-new"><% loc('Refers to') %></option>
-<option value="new-RefersTo"><% loc('Referred to by') %></option>
+<option value="DependsOn-new" <% (lc(RT->Config->Get('SpawnTicketInQueueLinkDefault')) eq 'depends on' ? 'selected' : '') %>><% loc('Depends on') %></option>
+<option value="new-DependsOn" <% (lc(RT->Config->Get('SpawnTicketInQueueLinkDefault')) eq 'depended on by ? 'selected' : '') %>><% loc('Depended on by') %></option>
+<option value="MemberOf-new" <% (lc(RT->Config->Get('SpawnTicketInQueueLinkDefault')) eq 'parents' ? 'selected' : '') %>><% loc('Parents') %></option>
+<option value="new-MemberOf" <% (lc(RT->Config->Get('SpawnTicketInQueueLinkDefault')) eq 'children' ? 'selected' : '') %>><% loc('Children') %></option>
+<option value="RefersTo-new" <% (lc(RT->Config->Get('SpawnTicketInQueueLinkDefault')) eq 'refers to' ? 'selected' : '') %>><% loc('Refers to') %></option>
+<option value="new-RefersTo" <% (lc(RT->Config->Get('SpawnTicketInQueueLinkDefault')) eq 'referred to by' ? 'selected' : '') %>><% loc('Referred to by') %></option>
 </select>
 <&|/l&>Ticket in</&>
 <& /Elements/SelectQueue, ShowNullOption => 0, Name => 'CloneQueue' &>


### PR DESCRIPTION
Easy improvement when a business need requires the link type to be preselected.
